### PR TITLE
make packet processing re-entrant - untested

### DIFF
--- a/src/lib/K7Chunker.h
+++ b/src/lib/K7Chunker.h
@@ -48,6 +48,8 @@ class K7Chunker : public AbstractChunker
         }
 
     private:
+        unsigned int _packetCount;
+        WritableData _writable;
         unsigned int _nPackets;
         unsigned int _packetsRejected;
         unsigned int _packetsAccepted;

--- a/src/lib/src/K7Chunker.cpp
+++ b/src/lib/src/K7Chunker.cpp
@@ -217,14 +217,15 @@ void K7Chunker::next(QIODevice* device)
             }
             ++_packetCount;
         }
+        _packetCount = 0;
         _chunksProcessed++;
         _chunkerCounter++;
+        _writable = WritableData(); // clear any data locks
         if (_chunkerCounter % 5 == 0)
         {
             std::cout << "K7Chunker::next(): " << _chunksProcessed << " chunks processed." << std::endl;
             //std::cout << "UTC timestamp " << timestamp << " accumulationNumber " << accumulation << " accumulationRate " << rate << std::endl;
         }
-        _writable = WritableData(); // clear any data locks
     }
     else
     {


### PR DESCRIPTION
Is there a unit test to try? I didn't find any so I've no idea if this works, but its worth a go.
The idea is you stop the datalock from going out of scope if there is a problem and recover from where you left off when you come back in to the routine, allowing the thread to service the socket in the meantime
